### PR TITLE
`aarch64-linux` support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1701693815,
-        "narHash": "sha256-7BkrXykVWfkn6+c1EhFA3ko4MLi3gVG0p9G96PNnKTM=",
+        "lastModified": 1707091808,
+        "narHash": "sha256-LahKBAfGbY836gtpVNnWwBTIzN7yf/uYM/S0g393r0Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "09ec6a0881e1a36c29d67497693a67a16f4da573",
+        "rev": "9f2ee8c91ac42da3ae6c6a1d21555f283458247e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -35,6 +35,7 @@
 
       eachDefaultSystem = eachSystem [
         "aarch64-darwin"
+        "aarch64-linux"
         "x86_64-darwin"
         "x86_64-linux"
       ];

--- a/pkgs/rustc0/default.nix
+++ b/pkgs/rustc0/default.nix
@@ -65,6 +65,13 @@ stdenv.mkDerivation rec {
           url = "https://github.com/risc0/rust/releases/download/test-release-2/rust-toolchain-aarch64-apple-darwin.tar.gz";
           sha256 = "sha256:0vvf6j14vm9n3kb39m0xdzfc7fdycwr3iqzlnyy7razgi3i5vk9l";
         }
+    else if stdenv.hostPlatform.system == "aarch64-linux"
+    then
+      builtins.fetchurl
+        {
+          url = "file://./rust-toolchain-aarch64-unknown-linux-gnu.tar.gz";
+          sha256 = "sha256:d9c6a874994adc3dbd5af275d0a4a4672792c099a8bc6358406da0073dc95297";
+        }
     else
       builtins.abort "Toolchain not available.";
 

--- a/pkgs/rustc0/default.nix
+++ b/pkgs/rustc0/default.nix
@@ -44,7 +44,7 @@ stdenv.mkDerivation rec {
   };
 
   src =
-    if stdenv.hostPlatform.isLinux
+    if stdenv.hostPlatform.system == "x86_64-linux"
     then
       builtins.fetchurl
         {
@@ -58,11 +58,15 @@ stdenv.mkDerivation rec {
           url = "https://github.com/risc0/rust/releases/download/test-release-2/rust-toolchain-x86_64-apple-darwin.tar.gz";
           sha256 = "sha256:1nhnsbclpmpsakf5vz77jbhh4ak7k30frh6hp4lg6aasmvif0fp3";
         }
+    else if stdenv.hostPlatform.system == "aarch64-darwin"
+    then
+      builtins.fetchurl
+        {
+          url = "https://github.com/risc0/rust/releases/download/test-release-2/rust-toolchain-aarch64-apple-darwin.tar.gz";
+          sha256 = "sha256:0vvf6j14vm9n3kb39m0xdzfc7fdycwr3iqzlnyy7razgi3i5vk9l";
+        }
     else
-      builtins.fetchurl {
-        url = "https://github.com/risc0/rust/releases/download/test-release-2/rust-toolchain-aarch64-apple-darwin.tar.gz";
-        sha256 = "sha256:0vvf6j14vm9n3kb39m0xdzfc7fdycwr3iqzlnyy7razgi3i5vk9l";
-      };
+      builtins.abort "Toolchain not available.";
 
   sourceRoot = ".";
 

--- a/pkgs/rustc0/rust-toolchain-aarch64-unknown-linux-gnu.tar.gz
+++ b/pkgs/rustc0/rust-toolchain-aarch64-unknown-linux-gnu.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d9c6a874994adc3dbd5af275d0a4a4672792c099a8bc6358406da0073dc95297
+size 401955176


### PR DESCRIPTION
Enable `aarch64-linux` support, by providing toolchain built on my Asahi Linux - https://github.com/cspr-rad/risc0pkgs/issues/10#issuecomment-1931977166.